### PR TITLE
db rollback/refactor

### DIFF
--- a/db/migrations/20170831170312_new_schema.js
+++ b/db/migrations/20170831170312_new_schema.js
@@ -7,28 +7,29 @@ exports.up = function(knex, Promise) {
     knex.schema.createTableIfNotExists('vendors', function(table) {
       table.increments('id').unsigned().primary();
       table.string('name', 100).notNullable();
-      table.string('url', 100).unique().notNullable();
+      table.string('url', 100).notNullable();
     }),
     knex.schema.createTableIfNotExists('products', function(table) {
       table.increments('id').unsigned().primary();
       table.string('name', 100).notNullable();
-      table.string('upc', 100).unique().notNullable();
+      table.string('upc', 100).notNullable();
       table.string('description', 255).notNullable();
     }),
-    knex.schema.createTableIfNotExists('product_urls', function(table) {
+    knex.schema.createTableIfNotExists('product_url', function(table) {
       table.increments('id').unsigned().primary();
       table.string('url', 100).notNullable();
-      table.integer('vendor_id').references('vendors.id').onDelete('CASCADE');
+      table.integer('vender_id').references('vendors.id').onDelete('CASCADE');
       table.integer('product_id').references('products.id').onDelete('CASCADE');
     }),
     knex.schema.createTableIfNotExists('prices', function(table) {
       table.increments('id').unsigned().primary();
-      table.integer('vendor_id').references('vendors.id').onDelete('CASCADE');
+      table.integer('vender_id').references('vendors.id').onDelete('CASCADE');
       table.integer('product_id').references('products.id').onDelete('CASCADE');
       table.decimal('price', 15, 2).notNullable();
-      table.timestamps();
+      table.date('data');
     }),
     knex.schema.createTableIfNotExists('followed_products', function(table) {
+      table.increments('id').unsigned().primary();
       table.integer('profile_id').references('profiles.id').onDelete('CASCADE');
       table.integer('product_id').references('products.id').onDelete('CASCADE');
     })
@@ -39,7 +40,7 @@ exports.down = function(knex, Promise) {
   return Promise.all([
     knex.schema.dropTable('followed_products'),
     knex.schema.dropTable('prices'),
-    knex.schema.dropTable('product_urls'),
+    knex.schema.dropTable('product_url'),
     knex.schema.dropTable('products'),
     knex.schema.dropTable('vendors'),
     knex.schema.table('profiles', (table) => {

--- a/db/migrations/20170909103455_refactor_prices.js
+++ b/db/migrations/20170909103455_refactor_prices.js
@@ -1,0 +1,44 @@
+
+exports.up = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.alterTable('vendors', function(table) {
+      table.string('url').notNullable().alter();
+    }),
+    knex.schema.alterTable('products', function(table) {
+      table.string('upc', 12).unique().notNullable().alter();
+      table.text('description').alter();
+    }),
+    knex.schema.renameTable('product_url', 'product_urls'),
+    knex.schema.alterTable('product_urls', function(table) {
+      table.renameColumn('vender_id', 'vendor_id');
+    }),
+    knex.schema.alterTable('prices', function(table) {
+      table.renameColumn('vender_id', 'vendor_id');
+      table.integer('price').notNullable().alter();
+      table.dropColumn('data');
+      table.timestamps();
+    }),
+  ]);
+};
+
+exports.down = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.alterTable('vendors', function(table) {
+      table.string('url', 100).notNullable().alter();
+    }),
+    knex.schema.alterTable('products', function(table) {
+      table.string('description', 255).notNullable().alter();
+      table.string('upc', 100).notNullable().alter();
+    }),
+    knex.schema.alterTable('product_urls', function(table) {
+      table.renameColumn('vendor_id', 'vender_id');
+    }),
+    knex.schema.renameTable('product_urls', 'product_url'),
+    knex.schema.alterTable('prices', function(table) {
+      table.renameColumn('vendor_id', 'vender_id');
+      table.decimal('price', 15, 2).notNullable().alter();
+      table.date('data');
+      table.dropTimestamps();
+    }),
+  ]);
+};

--- a/db/seeds/products_seed.js
+++ b/db/seeds/products_seed.js
@@ -36,14 +36,14 @@ exports.seed = function(knex, Promise) {
       return models.Price.forge({
         vendor_id: vendorId,
         product_id: productId,
-        price: 9999.99,
+        price: 999999,
       }).save();
     })
     .then(() => {
       return models.Price.forge({
         vendor_id: vendorId,
         product_id: productId,
-        price: 1234.56,
+        price: 123456,
       }).save();
     })
     .catch(err => {

--- a/server/test/productModel.spec.js
+++ b/server/test/productModel.spec.js
@@ -60,10 +60,10 @@ describe('Product model', () => {
         var price2 = product.related('prices').at(1);
 
         expect(price1.get('name')).toBe('Amazon');
-        expect(parseFloat(price1.get('price'))).toBe(1234.56);
+        expect(price1.get('price')).toBe(123456);
 
         expect(price2.get('name')).toBe('Amazon');
-        expect(parseFloat(price2.get('price'))).toBe(9999.99);
+        expect(price2.get('price')).toBe(999999);
 
         expect(price1.get('timestamp').getTime())
           .toBeGreaterThan(price2.get('timestamp').getTime());


### PR DESCRIPTION
This rolls back the new schema migration to be what @theenderweggin original wrote (with linter fixes) and creates a new migration to rename some columns, change price to an int.

From now on, any db migrations should be as narrowly defined as possible. There should not be any Promise.all chains, everything is one change per file to keep it more readable. Adding tons of changes in one file and trying to write the up/down in reverse order is not easy.