### PR TITLE
db price fix

### DIFF
--- a/client/src/components/Results.jsx
+++ b/client/src/components/Results.jsx
@@ -20,7 +20,7 @@ const Results = (props) => {
                 <p>{el.description}</p>
                 <p>
                   <Button bsStyle="primary"><Glyphicon glyph="eye-open"/> Track</Button>&nbsp;
-                  <a target="_blank" href={`${el.itemURL}`}><Button bsStyle="default"> {el.price}</Button>
+                  <a target="_blank" href={`${el.itemURL}`}><Button bsStyle="default"> ${el.price / 100}</Button>
                   </a>
                 </p>
               </Thumbnail>

--- a/server/middleware/amazon.js
+++ b/server/middleware/amazon.js
@@ -58,7 +58,7 @@ const normalizeAmazonData = function(amazonData) {
     }
 
     if (attributes.ListPrice) {
-      item.price = (attributes.ListPrice.FormattedPrice);
+      item.price = parseInt(attributes.ListPrice.Amount);
     } else {
       console.log('no list price');
     }


### PR DESCRIPTION
The price must be an int for the database! Storing it as a string, or even as a decimal is a bad idea. This also fixes the one place (I could find) on the client that displays the price and formats it.