### PR TITLE
Fix Heroku url field length

### DIFF
--- a/db/migrations/20170915184120_product_url_length.js
+++ b/db/migrations/20170915184120_product_url_length.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex, Promise) {
+  return knex.schema.alterTable('product_urls', table => {
+    table.string('url', 255).notNullable().alter();
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.alterTable('product_urls', table => {
+    table.string('url', 100).notNullable().alter();
+  });
+};


### PR DESCRIPTION
It seems like when you alter a table you do need to explicitly change the length instead of assuming the default length will override it.