### PR TITLE
drop down list added to track button on results entry

### DIFF
--- a/client/src/components/ResultsEntries.jsx
+++ b/client/src/components/ResultsEntries.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Row, Col } from 'react-bootstrap';
-import { Thumbnail, Button, Glyphicon } from 'react-bootstrap';
+import { Thumbnail, Button, Glyphicon} from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import '../styles/main.scss';
+import Track from './Track.jsx';
 
 const ResultsEntries = (props) => (
   <Row>
@@ -17,7 +18,7 @@ const ResultsEntries = (props) => (
             </Link>
             <p>{el.description}</p>
             <p>
-              <Button bsStyle="primary"><Glyphicon glyph="eye-open"/> Track</Button>&nbsp;
+              <Track />&nbsp;
               <a target="_blank" href={`${el.itemURL}`}><Button bsStyle="default"> ${el.price / 100}</Button>
               </a>
             </p>
@@ -34,5 +35,5 @@ const mapStateToProps = (state) => {
   };
 };
 
-export const UnwrappedSearch = ResultsEntries;
+export const UnwrappedResultsEntries = ResultsEntries;
 export default connect(mapStateToProps)(ResultsEntries);

--- a/client/src/components/Track.jsx
+++ b/client/src/components/Track.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Row, Col } from 'react-bootstrap';
+import { Thumbnail, Button, Glyphicon, Dropdown, DropdownButton, ButtonToolbar, MenuItem, RootCloseWrapper, CustomToggle, CustomMenu} from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
+import '../styles/main.scss';
+import store from '../store';
+
+const Track = (props) => {
+
+  var userList = ['UserListItem1', 'UserListItem2', 'UserListItem3', 'UserListItem4'];
+
+  //after db set with 
+  const mapList = userList.map( (item, index) => {
+         return <MenuItem eventKey={index}>{item}</MenuItem>
+          });
+  //add link to profile page 
+  mapList.push(<MenuItem eventKey={'last'}><Link to={'/profile'}>Create New List</Link></MenuItem>)
+
+  return (
+      <DropdownButton bsStyle="primary" title={<span><Glyphicon glyph="eye-open"/> Title</span>}>
+        { mapList }
+      </DropdownButton>
+  );
+};
+
+// const mapStateToProps = (state) => {
+//   return {
+//     'user': state.user.list
+//   };
+// };
+
+//connect(mapStateToProps)(Track);
+
+export default Track;


### PR DESCRIPTION
- Drop down list added to track button on results entry
- Last item in the drop down labled "create new list" is a link to the profile page (where they may create a new list)

💩 This functionality as currently implemented takes the user away from what they wanted to track if they attempt to make a new list (presumably to put this item into). 💩 